### PR TITLE
docs: fix memos id to new version

### DIFF
--- a/content/posts/weekly/weekly-review-2024.md
+++ b/content/posts/weekly/weekly-review-2024.md
@@ -19,7 +19,7 @@ feature: https://r2.immmmm.com/2024/11/SCR-20241123-peou.png.webp
 ![wk19-miss-1](https://r2.immmmm.com/2024/03/wk19-miss-1.jpg)
 ![wk19-miss-2](https://r2.immmmm.com/2024/03/wk19-miss-2.jpg)
 
-24年3月（via [@大大的小蜗牛](https://memos.eallion.com/m/6238)）
+24年3月（via [@大大的小蜗牛](https://memos.eallion.com/m/86cdeaf66f31251a)）
 
 ### 走过
 


### PR DESCRIPTION
抱歉，打扰了。
Memos 老版本和新版本中间，还有些过渡版本，那些版本会自动处理数据，ID 会自动变化，那期间发布的 Memos 会变成不是现在这样的 Uid 也不是老版本的 ID。
修复了一下，同步成数据库中的 ID 了。